### PR TITLE
Only process Events from Hears attribute

### DIFF
--- a/src/Events/Attributes/AttributeStrategy.php
+++ b/src/Events/Attributes/AttributeStrategy.php
@@ -2,6 +2,7 @@
 
 namespace Collective\Annotations\Events\Attributes;
 
+use Collective\Annotations\Events\Attributes\Attributes\Hears;
 use Collective\Annotations\Events\ScanStrategyInterface;
 use ReflectionAttribute;
 use ReflectionMethod;
@@ -15,7 +16,10 @@ class AttributeStrategy implements ScanStrategyInterface
     {
         return array_map(
             fn (ReflectionAttribute $attribute) => $attribute->newInstance()->events,
-            $method->getAttributes()
+            array_filter(
+                $method->getAttributes(),
+                fn (ReflectionAttribute $attribute) => $attribute->getName() == Hears::class
+            ),
         );
     }
 }


### PR DESCRIPTION
The getEvents function was processing all attributes, instead of only Hears, so something like this:
```
class TestRepository
{
    #[Hears(MyEvent::class)]
    public function a()
    {
    }

    #[MyAttribute(MyEvent::class)]
    public function b()
    {
    }
}
```
would generate 2 listeners in the `events.scanned.php` file.

(I dont think the `MyEvent::class` argument is relevant, only posting because that was my case)